### PR TITLE
feat(example): how to type-safe access state, actions and getters nested module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -41,7 +41,7 @@ const config = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node', 'vue'],
   coverageDirectory: './coverage/',
   collectCoverage: false,
-  collectCoverageFrom: ['./src/**', '!./src/i18n/**', '!./src/store/**'],
+  collectCoverageFrom: ['./src/**', '!./src/i18n/**'],
   snapshotSerializers: ['jest-serializer-vue'],
 };
 

--- a/src/store/todo/index.ts
+++ b/src/store/todo/index.ts
@@ -3,21 +3,28 @@ import actions from '@/store/todo/actions';
 import mutations from '@/store/todo/mutations';
 import getters from '@/store/todo/getters';
 import * as Store from '@/types/store';
+import * as Sub1 from '@/store/todo/sub1';
 
 export * from '@/store/todo/state';
 
 export { state, actions, mutations, getters };
 
 export type StateTree = {
-  todo: State;
-};
+  todo: State & {
+    sub1: Sub1.StateTree;
+  };
+} & Sub1.StateTree;
 
 export type RootState = Pick<StateTree, 'todo'>;
 
 export type GetterTree = {
-  todo: Store.GetterReturnType<typeof getters>;
-};
+  todo: Store.GetterReturnType<typeof getters> & {
+    sub1: Sub1.GetterTree;
+  };
+} & Sub1.GetterTree;
 
 export type ActionTree = {
-  todo: Store.DispatchArgs<typeof actions>;
-};
+  todo: Store.DispatchArgs<typeof actions> & {
+    sub1: Sub1.ActionTree;
+  };
+} & Sub1.ActionTree;

--- a/src/store/todo/mutations.ts
+++ b/src/store/todo/mutations.ts
@@ -22,7 +22,9 @@ const mutations = {
   },
   resetState(state: State) {
     const resetState = defaultState();
-    for (const key of Object.keys(state) as Array<keyof State>) {
+    for (const key of Object.keys(resetState) as Array<
+      keyof typeof resetState
+    >) {
       state[key] = resetState[key];
     }
   },

--- a/src/store/todo/sub1/index.ts
+++ b/src/store/todo/sub1/index.ts
@@ -1,0 +1,54 @@
+import { MutationTree, ActionTree, GetterTree } from 'vuex';
+import { RootState } from '@/store/module_mapper';
+import { ActionContext } from '@/types/store';
+import * as Store from '@/types/store';
+
+export const state = () => ({
+  name: 'sub module 1',
+  counter: 0,
+});
+
+export type State = ReturnType<typeof state>;
+export interface StateTree {
+  'todo/sub1': State;
+}
+
+// ---------------------------------------------
+
+export const mutations = {
+  increment(state: State) {
+    state.counter += 1;
+  },
+};
+
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+const _checkMutationTypes: MutationTree<State> = mutations; // don't remove this line;
+
+// ---------------------------------------------
+
+export const getters = {
+  currentNumber: (state: State) => `current value is ${state.counter}`,
+};
+
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+const _checkGetterTypes: GetterTree<State, Context['rootState']> = getters; // don't remove this line;
+
+export interface GetterTree {
+  'todo/sub1': Store.GetterReturnType<typeof getters>;
+}
+
+// ---------------------------------------------
+
+type Context = ActionContext<State, typeof mutations, RootState>;
+export const actions = {
+  increment(ctx: Context) {
+    ctx.commit('increment', undefined);
+  },
+};
+
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
+const _checkActionTypes: ActionTree<State, Context['rootState']> = actions; // don't remove this line;
+
+export interface ActionTree {
+  'todo/sub1': Store.DispatchArgs<typeof actions>;
+}


### PR DESCRIPTION
# Example

https://github.com/Yama-Tomo/vue-vuex-typescript-sample/pull/325

> ### new feature 🚀 
> - Support access to state, actions and getters in nested modules


[how to access of this module](https://github.com/Yama-Tomo/vue-vuex-typescript-sample/pull/326/files#diff-0adbc25f5ce0821588fe1a09a7e1795c) in component file

### access via parent module

```typescript
import { getState, getActions, getGetters } from '@/store/helper';

...snip...

const state = getState('todo', this.$store);
const actions = getActions('todo', this.$store);
const getters = getGetters('todo', this.$store);

state.sub1.counter;
actions.sub1.increment;
getters.sub1.currentNumber;
```

### access sub module directly 

```typescript
import { getState, getActions, getGetters } from '@/store/helper';

...snip...

const state = getState('todo/sub1', this.$store);
const actions = getActions('todo/sub1', this.$store);
const getters = getGetters('todo/sub1', this.$store);

state.counter;
actions.increment;
getters.currentNumber;
```

### call other getters in action

`RootGetters` is `any` yet, because type definition very hard.

But there is a workaround using `getGetters`.

```typescript
import { getGetters } from '@/store/helper';

...snip...

const actions = {
  fooAction(ctx: Context) {
    const getters = getGetters('todo', ctx.rootGetters);
    getters.sub1.currentNumber;

    const gettersSub = getGetters('todo/sub1', ctx.rootGetters);
    gettersSub.currentNumber;
  },
```






